### PR TITLE
fix: Make _tcpClient and _udpClient readonly fields

### DIFF
--- a/NetSdrClientApp/NetSdrClient.cs
+++ b/NetSdrClientApp/NetSdrClient.cs
@@ -14,10 +14,8 @@ namespace NetSdrClientApp
 {
     public class NetSdrClient
     {
-        private ITcpClient _tcpClient;
-        private IUdpClient _udpClient;
-
-
+        private readonly ITcpClient _tcpClient;
+        private readonly IUdpClient _udpClient;
 
         public bool IQStarted { get; set; }
 


### PR DESCRIPTION
Виправлено проблему якості коду, виявлену SonarQube (csharpsquid:S2933).

Що було змінено:
- Додано модифікатор `readonly` до поля `_tcpClient`
- Додано модифікатор `readonly` до поля `_udpClient`
Чому це важливо:
Поля `_tcpClient` та `_udpClient` призначаються лише один раз у конструкторі класу `NetSdrClient` і ніколи не перепризначаються протягом життєвого циклу об'єкта. Використання модифікатора `readonly` забезпечує:

1. Покращену підтримуваність коду: Явно вказує, що ці залежності не змінюються після ініціалізації
2. Запобігання помилкам: Компілятор не дозволить випадкове перепризначення цих полів
