### PR TITLE
fix: Mark _tcpClient and _udpClient as readonly fields

### DIFF
--- a/NetSdrClientApp/NetSdrClient.cs
+++ b/NetSdrClientApp/NetSdrClient.cs
@@ -14,8 +14,8 @@ namespace NetSdrClientApp
 {
     public class NetSdrClient
     {
-        private ITcpClient _tcpClient;
-        private IUdpClient _udpClient;
+        private readonly ITcpClient _tcpClient;
+        private readonly IUdpClient _udpClient;
 
         public bool IQStarted { get; set; }
 


### PR DESCRIPTION

Виправлено попередження статичного аналізатора коду SonarQube squid:S2933.

Проблема

Поля `_tcpClient` та `_udpClient` у класі `NetSdrClient` призначаються тільки в конструкторі і ніколи не змінюються протягом життєвого циклу об'єкта. Відповідно до правил якості коду, такі поля повинні бути позначені як `readonly`.

 Рішення

Додано модифікатор `readonly` до полів:
- `_tcpClient` (ITcpClient)
- `_udpClient` (IUdpClient)





Покращена підтримуваність: Явна вказівка, що поля незмінні після ініціалізації
Запобігання помилкам: Компілятор заборонить випадкове перепризначення
Відповідність стандартам: Усунуто попередження SonarQube squid:S2933
Кращий дизайн: Демонструє намір незмінності залежностей
<img width="915" height="83" alt="51a8ad6c-1ae8-490a-9545-dea1b57c947d" src="https://github.com/user-attachments/assets/508bc32f-a245-422e-aa82-5cf7cf78ccc5" />

 Змінені файли

- `NetSdrClient.cs` - додано `readonly` модифікатори до полів

