### PR TITLE
fix: Make responseTaskSource nullable to satisfy CS8618

### DIFF
--- a/NetSdrClientApp/NetSdrClient.cs
+++ b/NetSdrClientApp/NetSdrClient.cs
@@ -131,7 +131,7 @@ namespace NetSdrClientApp
             }
         }
 
-        private TaskCompletionSource<byte[]> responseTaskSource;
+        private TaskCompletionSource<byte[]>? responseTaskSource;
 
         private async Task<byte[]> SendTcpRequest(byte[] msg)
         {


### PR DESCRIPTION

<img width="1164" height="813" alt="image" src="https://github.com/user-attachments/assets/d7d31bd7-59f5-467f-bf3b-1601eb967e2a" />

Виправлено попередження статичного аналізатора коду SonarQube S2933.
Поле `responseTaskSource` не ініціалізується в конструкторі і може бути `null`, але було оголошено як non-nullable reference type.
Змінено тип з `TaskCompletionSource<byte[]>` на `TaskCompletionSource<byte[]>?
- Усунуто попередження компілятора
- Явно вказано, що поле може бути null
- Покращена типобезпека коду
- 
<img width="986" height="69" alt="image" src="https://github.com/user-attachments/assets/2f516222-2310-43ef-a06c-d708664dd243" />
